### PR TITLE
enable Graal VM Native image build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ libraryDependencies ++= Seq(
 
 enablePlugins(JavaAppPackaging)
 enablePlugins(DockerPlugin)
+enablePlugins(GraalVMNativeImagePlugin)
 mainClass in Compile := Some("gepriscrawler.App")
 
 scalacOptions in Test ++= Seq("-Yrangepos")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.1
+sbt.version = 1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.2.2")
+addSbtPlugin("com.github.sbt" %% "sbt-native-packager" % "1.9.4")


### PR DESCRIPTION
Unfortunately the build is a fallback version with packed JVM. But it can run standalone w/o any dependencies beside of glibc.